### PR TITLE
FIX erroneous label on sprite obj

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -13,7 +13,7 @@ int org_w, org_h;                                       // original size
 
 void error( int line, char *w, ... );
 void SaveRGB( char *filename, char *palname, BYTE *data, int type, int size, int line );
-void SaveSprite( char *filename, BYTE *data, int len, int line, int type );
+void SaveSprite( char *filename, char *spritesname, BYTE *data, int len, int line, int type );
 uint32_t LoadFile( char *filename, BYTE **adr );
 long ConvertFile( BYTE *in, long in_size, int type, int *in_h, int *in_w, int line );
 
@@ -683,7 +683,7 @@ void SaveRGB( char *filename, char *palname, BYTE *pal, int type, int size, int 
   }
 }
 
-void SaveSprite( char *filename, BYTE *ptr, int size, int line, int type )
+void SaveSprite( char *filename, char *spritename, BYTE *ptr, int size, int line, int type )
 {
   if ( type != C_HEADER ) {
     int handle;
@@ -696,16 +696,12 @@ void SaveSprite( char *filename, BYTE *ptr, int size, int line, int type )
     close( handle );
   } else {
     FILE * out;
-    char label[34] = "_";
+    char label[129] = "_";
     int i, o, segdata;
-    char * dot;
     if ( ( out = fopen( filename, "wb" ) ) == NULL ) {
       error( line, "Couldn't open %s !\n", filename );
     }
-    dot = strrchr( filename, '.' );
-    *dot = 0;
-    strcat( label, filename );
-    *dot = '.';
+    strcat( label, spritename );
     segdata = size + ( ( size+0x1f ) >> 5 );
     putc( 0xfd, out );
     putc( 0xfd, out ); /*magic*/

--- a/src/io.c
+++ b/src/io.c
@@ -13,7 +13,7 @@ int org_w, org_h;                                       // original size
 
 void error( int line, char *w, ... );
 void SaveRGB( char *filename, char *palname, BYTE *data, int type, int size, int line );
-void SaveSprite( char *filename, char *spritesname, BYTE *data, int len, int line, int type );
+void SaveSprite( char *filename, char *spritename, BYTE *data, int len, int line, int type );
 uint32_t LoadFile( char *filename, BYTE **adr );
 long ConvertFile( BYTE *in, long in_size, int type, int *in_h, int *in_w, int line );
 

--- a/src/sprpck.c
+++ b/src/sprpck.c
@@ -75,7 +75,7 @@ int global_dbg = 0;
 /* io.c */
 extern void error( int line, char *w, ... );
 extern void SaveRGB( char *filename, char *palname,  BYTE *data, int type, int size, int line );
-extern void SaveSprite( char *filename, BYTE *data, int len, int line, int tzpe );
+extern void SaveSprite( char *filename, char *spritename, BYTE *data, int len, int line, int tzpe );
 extern uint32_t LoadFile( char *filename, BYTE **adr );
 extern long ConvertFile( BYTE *in, long in_size, int type,
                          int *in_w, int *in_h, int line );
@@ -1131,7 +1131,9 @@ int main( int argc, char *argv[] )
           } else {
             sprintf( outfile2, "%s%3.3d%3.3d%s", outfile, t_yy, t_xx, extension );
           }
-          SaveSprite( outfile2, out, ret, line, pal_output );
+          char spritename[128];
+          getCleanName(spritename, outfile2);
+          SaveSprite( outfile2, spritename, out, ret, line, pal_output );
           free( out );
         } else {
           error( line, "Packed size = 0!" );


### PR DESCRIPTION
if output is on a sub folder, ouput filename is "sub/file.ext"
when building a sprite obj (-p0 arg), this filename is used as label for the object and so is saved as "_sub/file"
the path delimiter is an invalid char for object name

<img width="620" alt="bmp4bit erroneous lable name" src="https://user-images.githubusercontent.com/34610339/159257305-889f046c-c2b4-4cc5-b229-41c7b9bb793e.png">




this code fix it, using same method as for pal name